### PR TITLE
Add Multiverse Colored world Aliases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,13 +3,21 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>ru.tehkode</groupId>
     <artifactId>ChatManager</artifactId>
-    <version>1.14</version>
+    <version>1.15</version>
     <name>ChatManager</name>
     <url>https://github.com/t3hk0d3/ChatManager</url>
     <issueManagement>
         <system>GitHub</system>
         <url>https://github.com/t3hk0d3/ChatManager/issues</url>
     </issueManagement>
+    <!-- Repo for Multiverse-Core Dependency -->
+    <repositories>
+        <repository>
+            <id>OnARandomBox</id>
+            <url>http://repo.onarandombox.com/artifactory/repo</url>
+        </repository>
+    </repositories>
+    <!-- Repo for Multiverse-Core Dependency -->
     <build>
         <finalName>${project.artifactId}</finalName>
         <plugins>
@@ -52,6 +60,15 @@
             <artifactId>PermissionsEx</artifactId>
             <version>1.14</version>
         </dependency>
+        <!-- Multiverse-Core Dependency -->
+        <dependency>
+            <groupId>com.onarandombox.multiversecore</groupId>
+            <artifactId>Multiverse-Core</artifactId>
+            <version>2.0</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <!-- Multiverse-Core Dependency -->
     </dependencies>
     
     <properties>

--- a/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
@@ -27,6 +27,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerChatEvent;
 import org.bukkit.event.player.PlayerListener;
 import org.bukkit.util.config.Configuration;
+
+import ru.tehkode.chatmanager.bukkit.utils.MultiverseConnector;
 import ru.tehkode.permissions.PermissionUser;
 import ru.tehkode.permissions.bukkit.PermissionsEx;
 
@@ -52,6 +54,7 @@ public class ChatListener extends PlayerListener {
     protected String optionGlobalMessageFormat = "global-message-format";
     protected String optionRangedMode = "force-ranged-mode";
     protected String optionDisplayname = "display-name-format";
+    private MultiverseConnector multiverseConnector;
 
     public ChatListener(Configuration config) {
         this.messageFormat = config.getString("message-format", this.messageFormat);
@@ -68,8 +71,6 @@ public class ChatListener extends PlayerListener {
         }
 
         Player player = event.getPlayer();
-        
-        String worldName = player.getWorld().getName();
 
         PermissionUser user = PermissionsEx.getPermissionManager().getUser(player);
         if (user == null) {
@@ -129,7 +130,7 @@ public class ChatListener extends PlayerListener {
         String worldName = player.getWorld().getName();  
         return format.replace("%prefix", this.colorize(user.getPrefix(worldName)))
                      .replace("%suffix", this.colorize(user.getSuffix(worldName)))
-                     .replace("%world", worldName)                     
+                     .replace("%world", this.getWorldAlias(worldName))                     
                      .replace("%player", player.getName());
     }
     
@@ -196,5 +197,26 @@ public class ChatListener extends PlayerListener {
         }
         
         return string.replaceAll("&([a-z0-9])", "\u00A7$1");
+    }
+    /**
+     * Initializes the MVConnector.
+     * 
+     * @param conn The MultiverseConnector instance
+     */
+    protected void setupMultiverseConnector(MultiverseConnector conn) {
+        this.multiverseConnector = conn;
+    }
+    
+    /**
+     * Returns a colored world string provided by Multiverse
+     * 
+     * @param world The world to retrieve the string about.
+     * @return A colored worldstring if the connector is present, the normal world if it is not.
+     */
+    private String getWorldAlias(String world) {
+        if(this.multiverseConnector != null) {
+            return multiverseConnector.getColoredAliasForWorld(world);
+        }
+        return world;
     }
 }

--- a/src/main/java/ru/tehkode/chatmanager/bukkit/ChatManager.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/ChatManager.java
@@ -34,6 +34,7 @@ public class ChatManager extends JavaPlugin {
     protected final static Logger logger = Logger.getLogger("Minecraft");
     
     protected ChatListener listener;
+    protected PluginListener pluginListener;
 
     public ChatManager() {
     }
@@ -56,10 +57,14 @@ public class ChatManager extends JavaPlugin {
         }
 
         this.listener = new ChatListener(config);
+        this.pluginListener = new PluginListener(this);
 
         if (config.getBoolean("enable", false)) {
             this.getServer().getPluginManager().registerEvent(Type.PLAYER_CHAT, this.listener, Priority.Normal, this);
+            this.getServer().getPluginManager().registerEvent(Type.PLUGIN_ENABLE, this.pluginListener, Priority.Normal, this);
             logger.info("[ChatManager] ChatManager enabled!");
+            // Make sure MV didn't load before we did.
+            this.pluginListener.checkForMultiverse(this.getServer().getPluginManager().getPlugin("Multiverse-Core"));
         } else {
             logger.info("[ChatManager] ChatManager disabled. Check config.yml!");
             this.getPluginLoader().disablePlugin(this);

--- a/src/main/java/ru/tehkode/chatmanager/bukkit/PluginListener.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/PluginListener.java
@@ -1,0 +1,29 @@
+package ru.tehkode.chatmanager.bukkit;
+
+import org.bukkit.event.server.PluginEnableEvent;
+import org.bukkit.event.server.ServerListener;
+import org.bukkit.plugin.Plugin;
+
+import ru.tehkode.chatmanager.bukkit.utils.MultiverseConnector;
+
+import com.onarandombox.MultiverseCore.MultiverseCore;
+
+public class PluginListener extends ServerListener {
+    private ChatManager plugin;
+
+    public PluginListener(ChatManager mgr) {
+        this.plugin = mgr;
+    }
+
+    @Override
+    public void onPluginEnable(PluginEnableEvent event) {
+        this.checkForMultiverse(event.getPlugin());
+    }
+
+    public void checkForMultiverse(Plugin p) {
+        if (p != null && p.getDescription().getName().equalsIgnoreCase("Multiverse-Core")) {
+            this.plugin.listener.setupMultiverseConnector(new MultiverseConnector((MultiverseCore) p));
+            ChatManager.logger.info("[ChatManager] Multiverse 2 integration enabled!");
+        }
+    }
+}

--- a/src/main/java/ru/tehkode/chatmanager/bukkit/utils/MultiverseConnector.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/utils/MultiverseConnector.java
@@ -1,0 +1,29 @@
+package ru.tehkode.chatmanager.bukkit.utils;
+
+import com.onarandombox.MultiverseCore.MVWorld;
+import com.onarandombox.MultiverseCore.MultiverseCore;
+
+/**
+ * Non-Intrusive Connector class. This allows users to continue freely using ChatManager without having MV installed.
+ */
+public class MultiverseConnector {
+    private MultiverseCore plugin;
+
+    public MultiverseConnector(MultiverseCore multiverseCore) {
+        this.plugin = multiverseCore;
+    }
+
+    /**
+     * Return a nicely formated colored string from Multiverse.
+     * 
+     * @param world The world name to retrieve the name for.
+     * @return A colored string if the world is managed by Multiverse, otherwise, just returns the string.
+     */
+    public String getColoredAliasForWorld(String world) {
+        MVWorld mvWorld = this.plugin.getWorldManager().getMVWorld(world);
+        if (mvWorld != null) {
+            return mvWorld.getColoredWorldString();
+        }
+        return world;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,7 +1,7 @@
 name: ChatManager
 main: ru.tehkode.chatmanager.bukkit.ChatManager
 depend: [ PermissionsEx ]
-version: 1.14
+version: 1.15
 author: t3hk0d3
 website: www.bukkit.org
 description: Chat management plugin from PermissionsEx


### PR DESCRIPTION
All i've done is added a Soft Dependency (tested with and without Multiverse-Core.jar) of Multiverse to allow users to set an alias in Multiverse (so it shows up pretty in `/mv who` and `/mv list`) and it will now use this colored string if someone adds `%world` in their ChatManager config. Here is a sample config of it working:

```
chat-range: 100.0
global-message-format: <%prefix%player%suffix> &e%message
enable: true
message-format: '[%world]<%prefix%player%suffix> &e%message'
ranged-mode: false
display-name-format: '%prefix%player%suffix'
```
