### PR TITLE
Allowance of multiple prefixes

### DIFF
--- a/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
@@ -315,7 +315,7 @@ public class ChatListener implements Listener {
 
         //this sets the player's personal prefix to be the prefix
         //which will be the final one if no perms are set
-        if (personalPrefix != null && !personalPrefix.trim().equalsIgnoreCase("")) {
+        if (personalPrefix.isEmpty()) {
             finalPrefix = personalPrefix;
         }
 
@@ -338,7 +338,7 @@ public class ChatListener implements Listener {
                 String prefix = group.getOwnPrefix();
                 if (prefix != null && !prefix.isEmpty()) { //just to make sure there is in fact a prefix to add
                     if (prefixBuffer) {
-                        if (finalPrefix.equalsIgnoreCase("")) { //in case there is no prefixes beforehand, prevents a ghost space
+                        if (finalPrefix.isEmpty()) { //in case there is no prefixes beforehand, prevents a ghost space
                             finalPrefix = prefix;
                         } else {
                             finalPrefix += " " + prefix;
@@ -358,7 +358,7 @@ public class ChatListener implements Listener {
                     String prefix = group.getOwnPrefix();
                     if (prefix != null && !prefix.isEmpty()) {
                         if (prefixBuffer) {
-                            if (finalPrefix.equalsIgnoreCase("")) {
+                            if (finalPrefix.isEmpty()) {
                                 finalPrefix = prefix;
                             } else {
                                 finalPrefix += " " + prefix;
@@ -372,7 +372,7 @@ public class ChatListener implements Listener {
         }
 
         //if there are no prefixes found perm-wise, this will set the group default prefix
-        if (finalPrefix.equalsIgnoreCase("")) {
+        if (finalPrefix.isEmpty()) {
             finalPrefix = user.getGroups()[0].getOwnPrefix();
         }
 
@@ -397,7 +397,7 @@ public class ChatListener implements Listener {
         PermissionGroup[] allGroups = PermissionsEx.getPermissionManager().getGroups();
         String finalSuffix = "";
 
-        if (personalSuffix != null && !personalSuffix.trim().equalsIgnoreCase("")) {
+        if (personalSuffix != null && !personalSuffix.isEmpty()) {
             finalSuffix = personalSuffix;
         }
 
@@ -415,7 +415,7 @@ public class ChatListener implements Listener {
                 String suffix = group.getOwnSuffix();
                 if (suffix != null && !suffix.isEmpty()) {
                     if (suffixBuffer) {
-                        if (finalSuffix.equalsIgnoreCase("")) {
+                        if (finalSuffix.isEmpty()) {
                             finalSuffix = suffix;
                         } else {
                             finalSuffix += " " + suffix;
@@ -434,7 +434,7 @@ public class ChatListener implements Listener {
                     String suffix = group.getOwnSuffix();
                     if (suffix != null && !suffix.isEmpty()) {
                         if (suffixBuffer) {
-                            if (finalSuffix.equalsIgnoreCase("")) {
+                            if (finalSuffix.isEmpty()) {
                                 finalSuffix = suffix;
                             } else {
                                 finalSuffix += " " + suffix;
@@ -448,7 +448,7 @@ public class ChatListener implements Listener {
             }
         }
 
-        if (finalSuffix.equalsIgnoreCase("")) {
+        if (finalSuffix.isEmpty()) {
             finalSuffix = user.getGroups()[0].getOwnSuffix();
         }
 

--- a/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
@@ -336,7 +336,7 @@ public class ChatListener implements Listener {
         for (PermissionGroup group : userGroups) {
             if (!group.has("*")) { //this is used to make sure all perms does not cause all suffixes
                 String prefix = group.getOwnPrefix();
-                if (prefix != null && !prefix.equals("null")) { //just to make sure there is in fact a prefix to add
+                if (prefix != null && !prefix.isEmpty()) { //just to make sure there is in fact a prefix to add
                     if (prefixBuffer) {
                         if (finalPrefix.equalsIgnoreCase("")) { //in case there is no prefixes beforehand, prevents a ghost space
                             finalPrefix = prefix;
@@ -356,7 +356,7 @@ public class ChatListener implements Listener {
             if (!user.inGroup(group)) { //this is used to make the groups they are already in are not re-added
                 if (user.has("prefix." + group.getName().toLowerCase())) {
                     String prefix = group.getOwnPrefix();
-                    if (prefix != null && !prefix.equals("null")) {
+                    if (prefix != null && !prefix.isEmpty()) {
                         if (prefixBuffer) {
                             if (finalPrefix.equalsIgnoreCase("")) {
                                 finalPrefix = prefix;
@@ -377,7 +377,7 @@ public class ChatListener implements Listener {
         }
 
         //if there is no prefix so far, just sets it to "" to remove the %prefix and not add anything
-        if (finalPrefix == null || finalPrefix.equalsIgnoreCase("null")) {
+        if (finalPrefix == null || finalPrefix.isEmpty()) {
             finalPrefix = "";
         }
         return finalPrefix;
@@ -413,7 +413,7 @@ public class ChatListener implements Listener {
         for (PermissionGroup group : userGroups) {
             if (!group.has("*")) {
                 String suffix = group.getOwnSuffix();
-                if (suffix != null && !suffix.equals("null")) {
+                if (suffix != null && !suffix.isEmpty()) {
                     if (suffixBuffer) {
                         if (finalSuffix.equalsIgnoreCase("")) {
                             finalSuffix = suffix;
@@ -432,7 +432,7 @@ public class ChatListener implements Listener {
             if (!user.inGroup(group)) {
                 if (user.has("suffix." + group.getName().toLowerCase())) {
                     String suffix = group.getOwnSuffix();
-                    if (suffix != null && !suffix.equals("null")) {
+                    if (suffix != null && !suffix.isEmpty()) {
                         if (suffixBuffer) {
                             if (finalSuffix.equalsIgnoreCase("")) {
                                 finalSuffix = suffix;
@@ -452,7 +452,7 @@ public class ChatListener implements Listener {
             finalSuffix = user.getGroups()[0].getOwnSuffix();
         }
 
-        if (finalSuffix == null || finalSuffix.equalsIgnoreCase("null")) {
+        if (finalSuffix == null || finalSuffix.isEmpty()) {
             finalSuffix = "";
         }
         return finalSuffix;


### PR DESCRIPTION
The extra code allows for multiple prefixes/suffixes to be given to a
user at once. All done thru the use of permissions and defaulting.
"prefix.<group>" will give a prefix from one group to another while if
no prefixes are assigned, will default to the group's prefix.

This is just a re-write of my previous pull and is done much better.
