### PR TITLE
Revert %player change

### DIFF
--- a/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
@@ -146,7 +146,7 @@ public class ChatListener implements Listener {
 	protected String replacePlayerPlaceholders(Player player, String format) {
 		PermissionUser user = PermissionsEx.getPermissionManager().getUser(player);
 		String worldName = player.getWorld().getName();
-		return format.replace("%prefix", this.translateColorCodes(user.getPrefix(worldName))).replace("%suffix", this.translateColorCodes(user.getSuffix(worldName))).replace("%world", this.getWorldAlias(worldName)).replace("%player", player.getDisplayName());
+		return format.replace("%prefix", this.translateColorCodes(user.getPrefix(worldName))).replace("%suffix", this.translateColorCodes(user.getSuffix(worldName))).replace("%world", this.getWorldAlias(worldName)).replace("%player", player.getName());
 	}
 
 	protected List<Player> getLocalRecipients(Player sender, String message, double range) {


### PR DESCRIPTION
The %player should use their real name, with %displayname dealing with the nicks. 

The "fix" that was submitted and accepted completely overrode the %player and rendered %displayname redundant. This reverts that.
