### PR TITLE
Deprecation removal and %group Tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,8 +45,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.2.4-R0.1-SNAPSHOT</version>
-            <type>jar</type>
+            <version>1.4.7-R1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>ru.tehkode</groupId>

--- a/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
+++ b/src/main/java/ru/tehkode/chatmanager/bukkit/ChatListener.java
@@ -28,7 +28,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerChatEvent;
+import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.server.PluginEnableEvent;
 import org.bukkit.plugin.Plugin;
 
@@ -83,7 +83,7 @@ public class ChatListener implements Listener {
 	}
 
 	@EventHandler
-	public void onPlayerChat(PlayerChatEvent event) {
+	public void onPlayerChat(AsyncPlayerChatEvent event) {
 		if (event.isCancelled()) {
 			return;
 		}
@@ -146,7 +146,7 @@ public class ChatListener implements Listener {
 	protected String replacePlayerPlaceholders(Player player, String format) {
 		PermissionUser user = PermissionsEx.getPermissionManager().getUser(player);
 		String worldName = player.getWorld().getName();
-		return format.replace("%prefix", this.translateColorCodes(user.getPrefix(worldName))).replace("%suffix", this.translateColorCodes(user.getSuffix(worldName))).replace("%world", this.getWorldAlias(worldName)).replace("%player", player.getDisplayName());
+		return format.replace("%prefix", this.translateColorCodes(user.getPrefix(worldName))).replace("%suffix", this.translateColorCodes(user.getSuffix(worldName))).replace("%world", this.getWorldAlias(worldName)).replace("%player", player.getDisplayName()).replace("%group", user.getGroupsNames()[0]);
 	}
 
 	protected List<Player> getLocalRecipients(Player sender, String message, double range) {


### PR DESCRIPTION
I installed PermissionsEX on my server with this chat manager, and had a few little nitpicks, such as this small one. This should help with Chat lag and, most importantly for me, allowed me to use the %group tag in config to show the player's user group, which was exactly what I needed.
